### PR TITLE
Adds mutex to SHA256withRSA for multi-threading

### DIFF
--- a/src/session.jl
+++ b/src/session.jl
@@ -11,8 +11,8 @@ using Dates, Base64
 #using Requests
 using HTTP, HTTP.Messages
 
-import JSON
-import MbedTLS
+using JSON: JSON
+using MbedTLS: MbedTLS
 
 using ..error
 using ..credentials
@@ -147,11 +147,10 @@ and signed using the private key provided in the Google JSON service-account key
 function JWS(credentials::JSONCredentials, claimset::JWTClaimSet, header::JWTHeader=JWTHeader("RS256"))
     payload = "$header.$claimset"
     signature = base64encode(SHA256withRSA(payload, credentials.private_key))
-    "$payload.$signature"
+    return "$payload.$signature"
 end
 
-function token(credentials::JSONCredentials,
-               scopes::AbstractVector{<: AbstractString})
+function token(credentials::JSONCredentials, scopes::AbstractVector{<: AbstractString})
     # construct claim-set from service account email and requested scopes
     claimset = JWTClaimSet(credentials.client_email, scopes)
     data = HTTP.URIs.escapeuri(Dict{Symbol, String}(

--- a/src/session.jl
+++ b/src/session.jl
@@ -18,21 +18,21 @@ using ..error
 using ..credentials
 using ..root
 
-global mbedtlslock = ReentrantLock()
+const MBEDTLSLOCK = ReentrantLock()
 """
     SHA256withRSA(message, key)
 
 Sign message using private key with RSASSA-PKCS1-V1_5-SIGN algorithm.
 """
 function SHA256withRSA(message, key::MbedTLS.PKContext)
-    lock(mbedtlslock)
+    lock(MBEDTLSLOCK)
     output = MbedTLS.sign(
         key,
         MbedTLS.MD_SHA256,
         MbedTLS.digest(MbedTLS.MD_SHA256, message),
         MbedTLS.MersenneTwister(0),
     )
-    unlock(mbedtlslock)
+    unlock(MBEDTLSLOCK)
     return output
 end
 

--- a/src/session.jl
+++ b/src/session.jl
@@ -6,10 +6,10 @@ module session
 export GoogleSession, authorize
 
 import Base: string, print, show
-using Dates, Base64 
+using Dates, Base64
 
 #using Requests
-using HTTP, HTTP.Messages 
+using HTTP, HTTP.Messages
 
 import JSON
 import MbedTLS
@@ -26,11 +26,14 @@ Sign message using private key with RSASSA-PKCS1-V1_5-SIGN algorithm.
 """
 function SHA256withRSA(message, key::MbedTLS.PKContext)
     lock(mbedtlslock)
-    output = MbedTLS.sign(key, MbedTLS.MD_SHA256,
-                 MbedTLS.digest(MbedTLS.MD_SHA256, message), MbedTLS.MersenneTwister(0)
-                 )
+    output = MbedTLS.sign(
+        key,
+        MbedTLS.MD_SHA256,
+        MbedTLS.digest(MbedTLS.MD_SHA256, message),
+        MbedTLS.MersenneTwister(0),
+    )
     unlock(mbedtlslock)
-    output
+    return output
 end
 
 """
@@ -147,7 +150,7 @@ function JWS(credentials::JSONCredentials, claimset::JWTClaimSet, header::JWTHea
     "$payload.$signature"
 end
 
-function token(credentials::JSONCredentials, 
+function token(credentials::JSONCredentials,
                scopes::AbstractVector{<: AbstractString})
     # construct claim-set from service account email and requested scopes
     claimset = JWTClaimSet(credentials.client_email, scopes)

--- a/src/session.jl
+++ b/src/session.jl
@@ -18,14 +18,20 @@ using ..error
 using ..credentials
 using ..root
 
+global mbedtlslock = ReentrantLock()
 """
     SHA256withRSA(message, key)
 
 Sign message using private key with RSASSA-PKCS1-V1_5-SIGN algorithm.
 """
-SHA256withRSA(message, key::MbedTLS.PKContext) = MbedTLS.sign(key, MbedTLS.MD_SHA256,
-    MbedTLS.digest(MbedTLS.MD_SHA256, message), MbedTLS.MersenneTwister(0)
-)
+function SHA256withRSA(message, key::MbedTLS.PKContext)
+    lock(mbedtlslock)
+    output = MbedTLS.sign(key, MbedTLS.MD_SHA256,
+                 MbedTLS.digest(MbedTLS.MD_SHA256, message), MbedTLS.MersenneTwister(0)
+                 )
+    unlock(mbedtlslock)
+    output
+end
 
 """
 GoogleSession(...)


### PR DESCRIPTION
MbedTLS has thread-safety issues (https://github.com/Mbed-TLS/mbedtls/issues/3391, https://github.com/Mbed-TLS/mbedtls/issues/3391), affecting GoogleCloud.jl. This lock seems to solve the problem.