### PR TITLE
upgrade mbedtls for the sake of thread-safety

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GoogleCloud"
 uuid = "55e21f81-8b0a-565e-b5ad-6816892a5ee7"
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 HTTP = "0.9, 1"
 JSON = "0.21"
 Libz = "1"
-MbedTLS = "1"
+MbedTLS = "1.1.1"
 MsgPack = "1"
 julia = "1.6"
 


### PR DESCRIPTION
Raising MbedTLS version to 1.1.1, as discussed in #48

I was trying to write an automate test reproducing the problem more easily, but I couldn't.

Perhaps merging this we could also close #34 #35 #42, and I suspect #31 as well